### PR TITLE
Fix Windows detection to work with Windows 10 Enterprise

### DIFF
--- a/lua/dbsession/init.lua
+++ b/lua/dbsession/init.lua
@@ -2,7 +2,7 @@ local api, fn, uv = vim.api, vim.fn, vim.loop
 local dbs = {}
 
 local function iswin()
-  return uv.os_uname().version == 'WindowsNT'
+  return uv.os_uname().sysname == 'Windows_NT'
 end
 
 local function path_sep()


### PR DESCRIPTION
Noticed an issue with Windows not being properly detected on my work machine, this should be compatible with any extant version of Windows these days.